### PR TITLE
Add basic meta tags for pages

### DIFF
--- a/src/main/java/com/jimple/generator/SimpleMarkdownGenerator.java
+++ b/src/main/java/com/jimple/generator/SimpleMarkdownGenerator.java
@@ -102,6 +102,8 @@ public class SimpleMarkdownGenerator implements MarkdownGenerator {
         data.put("title", file.properties().title());
         data.put("date", file.properties().date());
         data.put("content", htmlContent);
+        data.put("description", file.properties().description());
+        data.put("thumbnailUrl", file.properties().thumbnailUrl());
 
         // 블로그 기본 정보
         data.put("blogTitle", config.title());

--- a/src/main/resources/templates/article.html
+++ b/src/main/resources/templates/article.html
@@ -3,6 +3,12 @@
     <head>
         <meta charset="UTF-8">
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
+        <meta name="description" content="{{description}}">
+        <meta property="og:type" content="article">
+        <meta property="og:title" content="{{title}} - {{blogTitle}}">
+        <meta property="og:description" content="{{description}}">
+        {{#thumbnailUrl}}<meta property="og:image" content="{{thumbnailUrl}}">{{/thumbnailUrl}}
+        <meta property="og:site_name" content="{{blogTitle}}">
         <title>{{title}} - {{blogTitle}}</title>
         <link rel="stylesheet" href="assets/jimple.css">
     </head>

--- a/src/main/resources/templates/index.html
+++ b/src/main/resources/templates/index.html
@@ -3,6 +3,12 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="description" content="{{blogDescription}}">
+    <meta property="og:type" content="website">
+    <meta property="og:title" content="{{blogTitle}}">
+    <meta property="og:description" content="{{blogDescription}}">
+    {{#logo}}<meta property="og:image" content="{{logo}}">{{/logo}}
+    <meta property="og:site_name" content="{{blogTitle}}">
     <title>{{blogTitle}}</title>
     <link rel="stylesheet" href="assets/jimple.css">
     <link rel="stylesheet" href="assets/index.css">

--- a/src/main/resources/templates/list.html
+++ b/src/main/resources/templates/list.html
@@ -3,6 +3,11 @@
 <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="description" content="{{blogDescription}}" />
+    <meta property="og:type" content="website" />
+    <meta property="og:title" content="{{blogTitle}}" />
+    <meta property="og:description" content="{{blogDescription}}" />
+    <meta property="og:site_name" content="{{blogTitle}}" />
     <title>{{blogTitle}}</title>
     <link rel="stylesheet" href="assets/jimple.css" />
     <link rel="stylesheet" href="assets/list.css" />


### PR DESCRIPTION
## Summary
- provide meta description and Open Graph tags for each HTML template
- expose description and thumbnail to templates

## Testing
- `./mvnw -q -DskipTests package` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6875bca0b67c832aabc42220d399f107